### PR TITLE
Import: com.dsi.ant.antradio_library.xml

### DIFF
--- a/proprietary/etc/permissions/com.dsi.ant.antradio_library.xml
+++ b/proprietary/etc/permissions/com.dsi.ant.antradio_library.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<permissions>
+    <library name="com.dsi.ant.antradio_library"
+            file="/system/framework/com.dsi.ant.antradio_library.jar"/>
+</permissions>


### PR DESCRIPTION
While building Cherish OS I encountered an error: FAILED: ninja: 'external/ant-wireless/antradio-library/com.dsi.ant.antradio_library.xml', needed by 'cherry/out/target/product/mi8937/vendor/etc/permissions/com.dsi.ant.antradio_library.xml', missing and no known rule to 
make it